### PR TITLE
Allow more flexibility in missing comments

### DIFF
--- a/BrightMinded-WordPress/ruleset.xml
+++ b/BrightMinded-WordPress/ruleset.xml
@@ -43,6 +43,8 @@
 		<exclude name="Squiz.Commenting.FileComment.Missing"/>
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
 		<exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType"/>
+		<exclude name="FileDocBlock.FileDocBlockMissing"/>
+		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
 
 		<!-- Using increment/ decrement operators can harm readability -->
 		<exclude name="Squiz.Operators.IncrementDecrementUsage.Found"/>

--- a/BrightMinded-WordPress/ruleset.xml
+++ b/BrightMinded-WordPress/ruleset.xml
@@ -43,7 +43,7 @@
 		<exclude name="Squiz.Commenting.FileComment.Missing"/>
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
 		<exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType"/>
-		<exclude name="FileDocBlock.FileDocBlockMissing"/>
+		<exclude name="Squiz.Commenting.ClassComment.Missing"/>
 		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
 
 		<!-- Using increment/ decrement operators can harm readability -->


### PR DESCRIPTION
@david-hide @danomurray @david02871 This stops the warnings for:

- Missing class description
- Missing property description

These are the two rules which I've found frequently annoy me when trying to meet our coding standards. I think this will make the rules much more permissive and maybe entice people to actually start following them! 