### PR TITLE
Enable inheritdoc

### DIFF
--- a/BrightMinded-WordPress/ruleset.xml
+++ b/BrightMinded-WordPress/ruleset.xml
@@ -134,4 +134,11 @@
 	<rule ref="WordPress.Arrays.CommaAfterArrayItem.NoComma">
 		<type>warning</type>
 	</rule>
+
+	<!-- Allow use of {@inheritdoc} -->
+	<rule ref="Squiz.Commenting.FunctionComment">
+        <properties>
+            <property name="skipIfInheritdoc" value="true"/>
+        </properties>
+    </rule>
 </ruleset>


### PR DESCRIPTION
This allows the use of `{@inheritDoc}` to avoid repeating docBlocks when repeatedly extending the same function.

The curly brackets are required, in keeping with the pseudo-standards https://docs.phpdoc.org/guide/guides/inheritance.html and https://pear.php.net/reference/PhpDocumentor-latest/phpDocumentor/tutorial_tags.inlineinheritdoc.pkg.html