### PR TITLE
Bring us back in line with WordPress brace standards

### DIFF
--- a/BrightMinded-WordPress/ruleset.xml
+++ b/BrightMinded-WordPress/ruleset.xml
@@ -19,11 +19,9 @@
 		<exclude name="WordPress.PHP.DisallowShortTernary"/>
 
 		<!-- BrightMinded projects follow different whitespace conventions than WordPress -->
-		<exclude name="Generic.Classes.OpeningBraceSameLine"/>
 		<exclude name="Generic.Files.EndFileNewline.NotFound"/>
 		<exclude name="Generic.Files.LineEndings"/>
 		<exclude name="Generic.Formatting.MultipleStatementAlignment"/>
-		<exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
 		<exclude name="Generic.WhiteSpace.ArbitraryParenthesesSpacing"/>
 		<exclude name="PEAR.Functions.FunctionDeclaration"/>
 		<exclude name="Squiz.ControlStructures.ControlSignature"/>
@@ -116,9 +114,6 @@
 		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
 		<exclude name="Squiz.Commenting.InlineComment.NotCapital.InvalidEndChar"/>
 	</rule>
-
-	<!-- Ensure opening brace of a function is on the line after the function declaration -->
-	<rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman"></rule>
 
 	<!-- BrightMinded use `else if` over `elseif` which is prefered by Wordpress -->
 	<rule ref="Squiz.ControlStructures.ElseIfDeclaration"></rule>


### PR DESCRIPTION
As voted for on Slack, this brings us back in-line with the WordPress coding standards.

Specifically:

```
if ($a == $b) {
  // Do some stuff
}
````

instead of:

```
if ($a == $b)
{
  // Do some stuff
}
```